### PR TITLE
Feat: add feature flag for python build

### DIFF
--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -37,8 +37,11 @@ rand_chacha = { version = "0.3.1", default-features = false }
 w3f-bls = { version = "0.1.3", default-features = false }
 sp-consensus-beefy-etf = { git = "https://github.com/ideal-lab5/idn-sdk.git", features = ["bls-experimental"]}
 sha2 = { version = "0.10.2", default-features = false }
-pyo3 = { version = "0.23.1", features = ["extension-module", "macros"], default-features = false }
-libc = "0.2"  # Make sure to use the latest version available
+pyo3 = { version = "0.23.1", features = ["extension-module", "macros"], default-features = false, optional = true }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.0"
+
+[features]
+default = []
+python = [ "pyo3" ]

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -1,6 +1,6 @@
 # WASM Bindings for Timelock
 
-This crate provides wasm compatibility for the timelock crate. It provides compatibility for both javascript and python (3+).
+This crate provides wasm compatibility for the timelock crate. It provides compatibility for both JavaScript and Python (3+).
 
 ## Build
 
@@ -22,7 +22,7 @@ First create a virtual env, then run:
 pip install maturin
 # specify your python version
 export PYO3_CROSS_PYTHON_VERSION="3.10"
-maturin develop
+maturin develop --features "python"
 ```
 
 #### Publish

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -15,4 +15,6 @@
  */
 
 pub mod js;
+
+#[cfg(feature = "python")]
 pub mod py;

--- a/wasm/src/py.rs
+++ b/wasm/src/py.rs
@@ -29,6 +29,7 @@ use timelock::{
 		TLECiphertext,
 	},
 };
+
 /// The encrypt wrapper used by the Python bindings to call tlock.rs encrypt
 /// function
 /// * 'id_py': ID string for which the message will be encrypted

--- a/wasm/wasm_build_py.sh
+++ b/wasm/wasm_build_py.sh
@@ -1,17 +1,2 @@
-#!/usr/bin/env bash
-#
-# This shell script compiles the rust library to WebAssembly and creates a JS package using wasm-pack. 
-# It also replaces any Node.js specific code with PythonMonkey code using sed.
-#
-# Note: this script is only compatible with unix.
-#
-
-cargo build
-# compiles rust code to wasm and creates a package targetting Node.js
-wasm-pack build --target nodejs
-
-# replaces calls to require('path') and require('fs') with pythonmonkey non Node.js equivalents
-NEW_READ_FILE_SYNC="function pyReadFileSync(filename) {\n  python.exec(\n\\\`\ndef getBytes(filename):\n  file = open(filename, 'rb')\n  return bytearray(file.read())\n\\\`\n  );\n  return python.eval('getBytes')(filename)\n}\n"
-
-find ./pkg/*js -type f -exec sed -i "s/require('path').join(\(.*\));/[\1]\.join('\/');/g" {} \;
-find ./pkg/*js -type f -exec sed -i "s/require('fs').readFileSync(\(.*\));/(${NEW_READ_FILE_SYNC})(\1)/g" {} \;
+cargo build --features "python" --release
+maturin develop --features "python"


### PR DESCRIPTION
- PyO3 was causing the wasm-pack tests top fail
- this adds a "python" feature flag that must be used to build the PyO3 bindings
- also updates documentation to indicate this