### PR TITLE
update code to reflect published npm versions

### DIFF
--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@ideallabs/timelock.js",
-  "version": "1.0.0-dev",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ideallabs/timelock.js",
-      "version": "1.0.0-dev",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "timelock-wasm-wrapper": "file:../wasm/pkg/js/"
+        "@ideallabs/timelock_wasm_wrapper": "1.0.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.26.0",
@@ -26,11 +26,13 @@
     "../wasm/pkg": {
       "name": "timelock-wasm-wrapper",
       "version": "0.0.1",
+      "extraneous": true,
       "license": "Apache-2.0"
     },
     "../wasm/pkg/js": {
       "name": "timelock_wasm_wrapper",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "Apache-2.0"
     },
     "node_modules/@ampproject/remapping": {
@@ -1733,6 +1735,12 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@ideallabs/timelock_wasm_wrapper": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ideallabs/timelock_wasm_wrapper/-/timelock_wasm_wrapper-1.0.0.tgz",
+      "integrity": "sha512-uMlQnfdpq5h65FwkyynyigtR0WA9f/B1+kvEIr6aHBlqacl4wGRWn/QqEf/koj/aYrqYWZHRS6FISivLih/N7w==",
+      "license": "Apache-2.0"
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -4688,10 +4696,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/timelock-wasm-wrapper": {
-      "resolved": "../wasm/pkg/js",
-      "link": true
     },
     "node_modules/tmpl": {
       "version": "1.0.5",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@ideallabs/timelock.js",
-  "version": "1.0.0-dev",
+  "version": "1.0.1",
   "description": "A typescript interface for timelock encryption.",
   "license": "Apache-2.0",
   "repository": "https://github.com/ideal-lab5/timelock",
   "main": "dist/index.js",
   "type": "module",
   "dependencies": {
-    "timelock-wasm-wrapper": "file:../wasm/pkg/js/"
+    "@ideallabs/timelock_wasm_wrapper": "1.0.0"
   },
   "scripts": {
     "build:wasm": "cd ../wasm && ./wasm_build.sh",

--- a/ts/src/interfaces/IDNIdentityBuilder.ts
+++ b/ts/src/interfaces/IDNIdentityBuilder.ts
@@ -15,7 +15,7 @@
  */
 
 import { IdentityBuilder } from './IIdentityBuilder'
-import { build_encoded_commitment } from 'timelock-wasm-wrapper'
+import { build_encoded_commitment } from '@ideallabs/timelock_wasm_wrapper'
 
 /**
  * An IdentityBuilder for the Ideal Network

--- a/ts/src/timelock.ts
+++ b/ts/src/timelock.ts
@@ -22,7 +22,7 @@ import init, {
   tle,
   tld,
   decrypt,
-} from 'timelock-wasm-wrapper'
+} from '@ideallabs/timelock_wasm_wrapper'
 import { IdentityBuilder } from './interfaces/IIdentityBuilder'
 
 /**


### PR DESCRIPTION
This pull request includes changes to the package.json files as well as two references to the timelock-wasm-wrapper. We now reference the published version @ideallabs/timelock_wasm_wrapper.