### PR TITLE
fix: add missing Safety documentation for FFI functions

### DIFF
--- a/.github/workflows/cross-platform-ffi.yml
+++ b/.github/workflows/cross-platform-ffi.yml
@@ -39,6 +39,7 @@ jobs:
     - name: Install system dependencies (macOS)
       if: matrix.os == 'macos-latest'
       run: |
+        brew uninstall --ignore-dependencies cmake || true
         brew install cmake pkg-config
     
     - name: Install system dependencies (Windows)

--- a/timelock-ffi/src/lib.rs
+++ b/timelock-ffi/src/lib.rs
@@ -563,6 +563,10 @@ pub unsafe extern "C" fn timelock_get_last_error() -> *const c_char {
 
 /// Get the version of the timelock library
 ///
+/// # Safety
+/// This function is safe to call from any context. It returns a pointer to
+/// static string data that remains valid for the lifetime of the program.
+///
 /// # Returns
 /// Null-terminated string with the version (static, no need to free)
 #[no_mangle]
@@ -575,6 +579,11 @@ pub unsafe extern "C" fn timelock_get_version() -> *const c_char {
 ///
 /// Call this function before using any other timelock functions.
 /// It's safe to call this multiple times.
+///
+/// # Safety
+/// This function is safe to call from any context and performs internal
+/// validation of cryptographic constants. No special safety requirements
+/// for the caller.
 ///
 /// # Returns
 /// `TimelockResult::Success` on success
@@ -596,6 +605,10 @@ pub unsafe extern "C" fn timelock_init() -> TimelockResult {
 ///
 /// Call this function when you're done using the timelock library.
 /// It's safe to call this multiple times.
+///
+/// # Safety
+/// This function is safe to call from any context and only cleans up
+/// internal library state. No special safety requirements for the caller.
 #[no_mangle]
 pub unsafe extern "C" fn timelock_cleanup() {
     // Clean up any global resources


### PR DESCRIPTION
- Add Safety sections to timelock_get_version(), timelock_init(), and timelock_cleanup()
- Resolves clippy missing_safety_doc warnings
- All functions are safe to call from any context despite unsafe extern C marking